### PR TITLE
feat: monorepo scaffold - pkg/protocol, Makefile, docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: build test run docker-up docker-down clean
+
+BINARY=claw-hub
+CMD_DIR=./cmd/server
+
+## build: compile the server binary
+build:
+	go build -o $(BINARY) $(CMD_DIR)
+
+## build-linux-arm64: cross-compile for Linux ARM64
+build-linux-arm64:
+	GOOS=linux GOARCH=arm64 go build -o $(BINARY)-linux-arm64 $(CMD_DIR)
+
+## test: run all tests
+test:
+	go test ./...
+
+## test-verbose: run tests with verbose output
+test-verbose:
+	go test -v ./...
+
+## run: run the server locally (requires docker-up for DB)
+run: build
+	./$(BINARY)
+
+## docker-up: start PostgreSQL and MongoDB via docker-compose
+docker-up:
+	docker compose up -d
+	@echo "Waiting for databases to be ready..."
+	@sleep 3
+	@docker compose ps
+
+## docker-down: stop and remove containers
+docker-down:
+	docker compose down
+
+## docker-logs: tail container logs
+docker-logs:
+	docker compose logs -f
+
+## clean: remove build artifacts
+clean:
+	rm -f $(BINARY) $(BINARY)-linux-arm64
+
+## help: show this help
+help:
+	@grep -E '^## ' Makefile | sed 's/## //'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: claw-hub-postgres
+    environment:
+      POSTGRES_USER: clawhub
+      POSTGRES_PASSWORD: clawhub
+      POSTGRES_DB: clawhub
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U clawhub"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  mongodb:
+    image: mongo:7
+    container_name: claw-hub-mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: clawhub
+      MONGO_INITDB_ROOT_PASSWORD: clawhub
+      MONGO_INITDB_DATABASE: clawhub
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  mongo_data:

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,3 @@
+// Package auth provides user authentication and API key management.
+// MVP implementation: JWT-based auth, no OAuth.
+package auth

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,36 @@
+# Database Migrations
+
+This directory contains SQL migration files for PostgreSQL.
+
+## Migration Tool
+
+We use [golang-migrate](https://github.com/golang-migrate/migrate) for schema migrations.
+
+### Install
+
+```bash
+go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+```
+
+### Usage
+
+```bash
+# Apply all pending migrations
+migrate -path ./migrations -database "postgres://clawhub:clawhub@localhost:5432/clawhub?sslmode=disable" up
+
+# Rollback last migration
+migrate -path ./migrations -database "postgres://clawhub:clawhub@localhost:5432/clawhub?sslmode=disable" down 1
+```
+
+### File Naming
+
+Migration files follow the pattern: `{version}_{description}.{up|down}.sql`
+
+Example:
+- `000001_create_agents_table.up.sql`
+- `000001_create_agents_table.down.sql`
+
+## Notes
+
+For MVP, the schema is auto-migrated via `store.Migrate()` in Go code.
+Explicit migration files will be added as the schema stabilizes.

--- a/pkg/protocol/PROTOCOL.md
+++ b/pkg/protocol/PROTOCOL.md
@@ -1,0 +1,39 @@
+# claw-hub Protocol
+
+WebSocket message envelope format for agent ↔ hub communication.
+
+## Message Envelope
+
+```json
+{
+  "type": "REGISTER | TASK_ASSIGN | TASK_UPDATE | TASK_RESULT | HEARTBEAT | ACK | MESSAGE",
+  "trace_id": "uuid",
+  "from": "agent_id | hub",
+  "to": "agent_id | hub",
+  "ts": "2026-03-07T04:57:00Z",
+  "payload": {},
+  "conversation_id": "uuid (optional)",
+  "depth": 0
+}
+```
+
+## Message Types
+
+| Type          | Direction        | Description                          |
+|---------------|------------------|--------------------------------------|
+| REGISTER      | agent → hub      | Agent connects and announces itself  |
+| TASK_ASSIGN   | hub → agent      | Hub assigns a task to an agent       |
+| TASK_UPDATE   | agent → hub      | Agent reports status change          |
+| TASK_RESULT   | agent → hub      | Agent submits final result           |
+| HEARTBEAT     | agent → hub      | Keep-alive ping (every 30s)          |
+| ACK           | hub ↔ agent      | Acknowledge message receipt          |
+| MESSAGE       | agent ↔ agent    | Direct agent-to-agent communication  |
+
+## Loop Prevention
+
+All agent-to-agent messages carry `conversation_id` and `depth`.
+Hub drops messages with `depth > 10` and emits a warning.
+
+## Go Structs
+
+See `envelope.go` for typed Go structs for each payload.

--- a/pkg/protocol/envelope.go
+++ b/pkg/protocol/envelope.go
@@ -1,0 +1,71 @@
+// Package protocol defines the WebSocket message protocol between agents and the hub.
+package protocol
+
+import "time"
+
+// MessageType defines the type of a message in the envelope.
+type MessageType string
+
+const (
+	TypeRegister   MessageType = "REGISTER"
+	TypeTaskAssign MessageType = "TASK_ASSIGN"
+	TypeTaskUpdate MessageType = "TASK_UPDATE"
+	TypeTaskResult MessageType = "TASK_RESULT"
+	TypeHeartbeat  MessageType = "HEARTBEAT"
+	TypeACK        MessageType = "ACK"
+	TypeMessage    MessageType = "MESSAGE" // agent-to-agent direct message
+)
+
+// Envelope is the standard message wrapper for all WebSocket communication.
+type Envelope struct {
+	Type        MessageType `json:"type"`
+	TraceID     string      `json:"trace_id"`
+	From        string      `json:"from"`         // agent_id or "hub"
+	To          string      `json:"to"`           // agent_id or "hub"
+	Timestamp   time.Time   `json:"ts"`
+	Payload     interface{} `json:"payload,omitempty"`
+
+	// Loop prevention fields
+	ConversationID string `json:"conversation_id,omitempty"`
+	Depth          int    `json:"depth,omitempty"`
+}
+
+// RegisterPayload is sent by an agent on connection to identify itself.
+type RegisterPayload struct {
+	Name         string   `json:"name"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// TaskAssignPayload is sent from hub to agent when a task is assigned.
+type TaskAssignPayload struct {
+	TaskID       string            `json:"task_id"`
+	Title        string            `json:"title"`
+	Requirements []string          `json:"requirements"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// TaskUpdatePayload is sent from agent to hub with a status update.
+type TaskUpdatePayload struct {
+	TaskID  string `json:"task_id"`
+	Status  string `json:"status"` // RUNNING | DONE | FAILED
+	Message string `json:"message,omitempty"`
+}
+
+// TaskResultPayload is sent from agent to hub with the final result.
+type TaskResultPayload struct {
+	TaskID string `json:"task_id"`
+	Result string `json:"result"`
+	Error  string `json:"error,omitempty"`
+}
+
+// HeartbeatPayload is sent periodically by agents to maintain online status.
+type HeartbeatPayload struct {
+	AgentID string `json:"agent_id"`
+}
+
+// ACKPayload acknowledges receipt of a message.
+type ACKPayload struct {
+	TraceID string `json:"trace_id"`
+	Status  string `json:"status"` // ok | error
+	Error   string `json:"error,omitempty"`
+}

--- a/pkg/protocol/envelope_test.go
+++ b/pkg/protocol/envelope_test.go
@@ -1,0 +1,50 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEnvelopeSerialization(t *testing.T) {
+	env := Envelope{
+		Type:      TypeRegister,
+		TraceID:   "test-trace-id",
+		From:      "agent-1",
+		To:        "hub",
+		Timestamp: time.Now(),
+		Payload: RegisterPayload{
+			Name:         "test-agent",
+			Capabilities: []string{"code", "search"},
+		},
+	}
+
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("failed to marshal envelope: %v", err)
+	}
+
+	var decoded Envelope
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal envelope: %v", err)
+	}
+
+	if decoded.Type != TypeRegister {
+		t.Errorf("expected type %s, got %s", TypeRegister, decoded.Type)
+	}
+	if decoded.TraceID != "test-trace-id" {
+		t.Errorf("expected trace_id test-trace-id, got %s", decoded.TraceID)
+	}
+}
+
+func TestMessageTypes(t *testing.T) {
+	types := []MessageType{
+		TypeRegister, TypeTaskAssign, TypeTaskUpdate,
+		TypeTaskResult, TypeHeartbeat, TypeACK, TypeMessage,
+	}
+	for _, mt := range types {
+		if mt == "" {
+			t.Error("empty message type found")
+		}
+	}
+}


### PR DESCRIPTION
## 变更内容

解除 Issue #2 的所有 blockers。

### 新增文件

- **`pkg/protocol/envelope.go`** — 完整 Go struct 定义所有消息类型：`REGISTER / TASK_ASSIGN / TASK_UPDATE / TASK_RESULT / HEARTBEAT / ACK / MESSAGE`，含 loop 防护字段 (`conversation_id`, `depth`)
- **`pkg/protocol/PROTOCOL.md`** — 协议文档，message type 对照表
- **`pkg/protocol/envelope_test.go`** — 序列化基础单测
- **`Makefile`** — `make build / test / run / docker-up / docker-down`
- **`docker-compose.yml`** — `postgres:16` + `mongo:7`，含 healthcheck
- **`internal/auth/auth.go`** — auth 包占位（#7 填充）
- **`migrations/README.md`** — golang-migrate 工具说明

### 解锁的 Issues

- Closes #2
- Unblocks #3（可莉可以立刻 push `envelope.go` 填充）
- Unblocks #4 ~ #11（全链路解封）

### 测试

```bash
make test  # pkg/protocol 单测通过
```