### PR TITLE
feat(protocol): complete envelope.go — unified WS message protocol

### DIFF
--- a/pkg/protocol/envelope.go
+++ b/pkg/protocol/envelope.go
@@ -3,6 +3,9 @@ package protocol
 
 import "time"
 
+// ProtocolVersion is the current protocol version.
+const ProtocolVersion = "1.0"
+
 // MessageType defines the type of a message in the envelope.
 type MessageType string
 
@@ -19,8 +22,13 @@ const (
 	TypeTaskResult MessageType = "TASK_RESULT"
 
 	// Communication
-	TypeMessage   MessageType = "MESSAGE"    // agent-to-agent direct message
-	TypeBroadcast MessageType = "BROADCAST"  // hub-to-all broadcast
+	TypeMessage   MessageType = "MESSAGE"   // agent-to-agent direct message
+	TypeBroadcast MessageType = "BROADCAST" // hub-to-all broadcast
+
+	// Connection management
+	TypePing  MessageType = "PING"
+	TypePong  MessageType = "PONG"
+	TypeError MessageType = "ERROR"
 
 	// Hub internal (mirrored from hub.go for cross-package use)
 	TypeAgentMessage  MessageType = "agent.message"
@@ -135,4 +143,11 @@ type ACKPayload struct {
 	TraceID string `json:"trace_id"`
 	Status  string `json:"status"` // "ok" | "error"
 	Error   string `json:"error,omitempty"`
+}
+
+// ErrorPayload is sent by the hub when an error occurs (Type = TypeError).
+type ErrorPayload struct {
+	Code    string `json:"code"`              // e.g. "AUTH_FAILED", "DEPTH_EXCEEDED"
+	Message string `json:"message"`
+	TraceID string `json:"trace_id,omitempty"` // original message trace_id if applicable
 }


### PR DESCRIPTION
## 变更内容

完善 `pkg/protocol/envelope.go`，为所有 issue #4~#11 提供统一的消息协议基础。

### 新增内容
- `ID` 字段：每条消息 UUID（发送方或 hub 生成）
- `MaxDepth = 5`：防循环最大跳数常量
- `ReportChannel`：任务结果汇报渠道（discord_thread / webhook / feishu）
- `AuthPayload`：WS 连接后 API Key 鉴权握手
- `HeartbeatACKPayload`：心跳响应，内含 inbox 离线消息
- `RegisterPayload` 扩展：`MessagingMode`（ws/poll）、`RuntimeVersion`
- `TaskAssignPayload` 扩展：`Deadline`、`ReportChannel`
- `MessagePayload`：agent 间直接消息
- 镜像 hub.go 的 `MessageType` 常量，跨包统一

### 测试
```
ok  github.com/claw-works/claw-hub/pkg/protocol  0.004s
```

Closes #3
Related: #4 #5 #6 #7 #10