### PR TITLE
feat: task report_channel + outgoing webhook notification (closes #10)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/claw-works/claw-hub/internal/agent"
 	"github.com/claw-works/claw-hub/internal/hub"
+	"github.com/claw-works/claw-hub/internal/notify"
 	"github.com/claw-works/claw-hub/internal/store"
 	"github.com/claw-works/claw-hub/internal/task"
 )
@@ -150,16 +151,17 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Title                string   `json:"title"`
-		Description          string   `json:"description"`
-		RequiredCapabilities []string `json:"required_capabilities"`
-		Priority             int      `json:"priority"`
+		Title                string              `json:"title"`
+		Description          string              `json:"description"`
+		RequiredCapabilities []string            `json:"required_capabilities"`
+		Priority             int                 `json:"priority"`
+		ReportChannel        *task.ReportChannel `json:"report_channel"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	t, err := s.tasks.Create(r.Context(), req.Title, req.Description, req.RequiredCapabilities, task.Priority(req.Priority))
+	t, err := s.tasks.Create(r.Context(), req.Title, req.Description, req.RequiredCapabilities, task.Priority(req.Priority), req.ReportChannel)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -234,6 +236,27 @@ func (s *Server) completeTask(w http.ResponseWriter, r *http.Request) {
 	}
 	t, _ := s.tasks.Get(r.Context(), id)
 	s.hub.Broadcast(hub.Message{Type: hub.MsgTypeBroadcast, Payload: map[string]interface{}{"event": "task.done", "task": t}})
+
+	// Fire outgoing webhook if report_channel is configured
+	if t != nil && t.ReportChannel != nil && t.ReportChannel.WebhookURL != "" {
+		go func() {
+			evt := notify.TaskEvent{
+				Event:           "task.done",
+				TaskID:          t.ID,
+				TaskTitle:       t.Title,
+				Status:          string(t.Status),
+				Result:          t.Result,
+				AssignedAgentID: t.AssignedAgentID,
+				CompletedAt:     *t.CompletedAt,
+				DiscordThreadID: t.ReportChannel.DiscordThreadID,
+				FeishuChatID:    t.ReportChannel.FeishuChatID,
+			}
+			if err := notify.Send(context.Background(), t.ReportChannel.WebhookURL, evt); err != nil {
+				log.Printf("completeTask: webhook error: %v", err)
+			}
+		}()
+	}
+
 	jsonResp(w, http.StatusOK, t)
 }
 
@@ -251,6 +274,27 @@ func (s *Server) failTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	t, _ := s.tasks.Get(r.Context(), id)
+
+	// Fire outgoing webhook if report_channel is configured
+	if t != nil && t.ReportChannel != nil && t.ReportChannel.WebhookURL != "" {
+		go func() {
+			evt := notify.TaskEvent{
+				Event:           "task.failed",
+				TaskID:          t.ID,
+				TaskTitle:       t.Title,
+				Status:          string(t.Status),
+				Error:           t.ErrorMsg,
+				AssignedAgentID: t.AssignedAgentID,
+				CompletedAt:     *t.CompletedAt,
+				DiscordThreadID: t.ReportChannel.DiscordThreadID,
+				FeishuChatID:    t.ReportChannel.FeishuChatID,
+			}
+			if err := notify.Send(context.Background(), t.ReportChannel.WebhookURL, evt); err != nil {
+				log.Printf("failTask: webhook error: %v", err)
+			}
+		}()
+	}
+
 	jsonResp(w, http.StatusOK, t)
 }
 

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -1,0 +1,59 @@
+// Package notify sends outgoing webhook notifications when tasks complete.
+// Hub calls this package; it never imports Discord or Feishu SDKs directly.
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// TaskEvent is the payload POSTed to the webhook URL on task completion.
+type TaskEvent struct {
+	Event           string         `json:"event"` // "task.done" | "task.failed"
+	TaskID          string         `json:"task_id"`
+	TaskTitle       string         `json:"task_title"`
+	Status          string         `json:"status"`
+	Result          string         `json:"result,omitempty"`
+	Error           string         `json:"error,omitempty"`
+	AssignedAgentID string         `json:"assigned_agent_id,omitempty"`
+	CompletedAt     time.Time      `json:"completed_at"`
+	// Opaque metadata forwarded from ReportChannel so the webhook receiver
+	// knows which Discord thread / Feishu chat to post into.
+	DiscordThreadID string `json:"discord_thread_id,omitempty"`
+	FeishuChatID    string `json:"feishu_chat_id,omitempty"`
+}
+
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
+// Send POSTs a TaskEvent to webhookURL. Errors are logged but not returned
+// to avoid breaking the task-completion response.
+func Send(ctx context.Context, webhookURL string, evt TaskEvent) error {
+	body, err := json.Marshal(evt)
+	if err != nil {
+		return fmt.Errorf("notify: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notify: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "claw-hub/1.0")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("notify: send: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("notify: webhook returned %d", resp.StatusCode)
+	}
+	log.Printf("notify: webhook %s → %d", webhookURL, resp.StatusCode)
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,10 +62,14 @@ func (db *DB) Migrate(ctx context.Context) error {
 			assigned_agent_id     TEXT,
 			result                TEXT,
 			error                 TEXT,
+			report_channel        JSONB,
 			created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			completed_at          TIMESTAMPTZ
 		);
+
+		-- Idempotent: add report_channel if the table already existed without it.
+		ALTER TABLE tasks ADD COLUMN IF NOT EXISTS report_channel JSONB;
 	`)
 	if err != nil {
 		return fmt.Errorf("migrate: %w", err)

--- a/internal/task/pg.go
+++ b/internal/task/pg.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -18,7 +19,7 @@ func NewPGStore(db *store.DB) *PGStore {
 	return &PGStore{db: db}
 }
 
-func (s *PGStore) Create(ctx context.Context, title, description string, required []string, priority Priority) (*Task, error) {
+func (s *PGStore) Create(ctx context.Context, title, description string, required []string, priority Priority, rc *ReportChannel) (*Task, error) {
 	t := &Task{
 		ID:                   uuid.New().String(),
 		Title:                title,
@@ -26,13 +27,24 @@ func (s *PGStore) Create(ctx context.Context, title, description string, require
 		RequiredCapabilities: required,
 		Priority:             priority,
 		Status:               StatusPending,
+		ReportChannel:        rc,
 		CreatedAt:            time.Now(),
 		UpdatedAt:            time.Now(),
 	}
+
+	var rcJSON []byte
+	if rc != nil {
+		var err error
+		rcJSON, err = json.Marshal(rc)
+		if err != nil {
+			return nil, fmt.Errorf("create task: marshal report_channel: %w", err)
+		}
+	}
+
 	_, err := s.db.PG.Exec(ctx,
-		`INSERT INTO tasks (id, title, description, required_capabilities, priority, status, created_at, updated_at)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-		t.ID, t.Title, t.Description, t.RequiredCapabilities, t.Priority, string(t.Status), t.CreatedAt, t.UpdatedAt,
+		`INSERT INTO tasks (id, title, description, required_capabilities, priority, status, report_channel, created_at, updated_at)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+		t.ID, t.Title, t.Description, t.RequiredCapabilities, t.Priority, string(t.Status), rcJSON, t.CreatedAt, t.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create task: %w", err)
@@ -44,7 +56,7 @@ func (s *PGStore) Create(ctx context.Context, title, description string, require
 func (s *PGStore) Get(ctx context.Context, id string) (*Task, error) {
 	row := s.db.PG.QueryRow(ctx,
 		`SELECT id,title,description,required_capabilities,priority,status,
-		        assigned_agent_id,result,error,created_at,updated_at,completed_at
+		        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
 		 FROM tasks WHERE id=$1`, id)
 	return scanTask(row)
 }
@@ -55,12 +67,12 @@ func (s *PGStore) List(ctx context.Context, statusFilter string) ([]*Task, error
 	if statusFilter == "" {
 		rows, err = s.db.PG.Query(ctx,
 			`SELECT id,title,description,required_capabilities,priority,status,
-			        assigned_agent_id,result,error,created_at,updated_at,completed_at
+			        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
 			 FROM tasks ORDER BY priority DESC, created_at ASC`)
 	} else {
 		rows, err = s.db.PG.Query(ctx,
 			`SELECT id,title,description,required_capabilities,priority,status,
-			        assigned_agent_id,result,error,created_at,updated_at,completed_at
+			        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
 			 FROM tasks WHERE status=$1 ORDER BY priority DESC, created_at ASC`, statusFilter)
 	}
 	if err != nil {
@@ -128,9 +140,10 @@ func scanTask(s scanner) (*Task, error) {
 	t := &Task{}
 	var status string
 	var assignedAgentID, result, errMsg *string
+	var rcJSON []byte
 	err := s.Scan(
 		&t.ID, &t.Title, &t.Description, &t.RequiredCapabilities,
-		&t.Priority, &status, &assignedAgentID, &result, &errMsg,
+		&t.Priority, &status, &assignedAgentID, &result, &errMsg, &rcJSON,
 		&t.CreatedAt, &t.UpdatedAt, &t.CompletedAt,
 	)
 	if err != nil {
@@ -146,5 +159,12 @@ func scanTask(s scanner) (*Task, error) {
 	if errMsg != nil {
 		t.ErrorMsg = *errMsg
 	}
+	if len(rcJSON) > 0 {
+		var rc ReportChannel
+		if err := json.Unmarshal(rcJSON, &rc); err == nil {
+			t.ReportChannel = &rc
+		}
+	}
 	return t, nil
 }
+

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -21,19 +21,31 @@ const (
 	PriorityHigh   Priority = 10
 )
 
+// ReportChannel describes where to send task completion notifications.
+// Hub calls WebhookURL (if set) with an HTTP POST when the task finishes.
+// DiscordThreadID / FeishuChatID are opaque metadata forwarded in the webhook
+// payload so the receiver knows which channel to post into — hub never calls
+// Discord or Feishu directly.
+type ReportChannel struct {
+	WebhookURL      string `json:"webhook_url,omitempty"`
+	DiscordThreadID string `json:"discord_thread_id,omitempty"`
+	FeishuChatID    string `json:"feishu_chat_id,omitempty"`
+}
+
 type Task struct {
-	ID                   string    `json:"id"`
-	Title                string    `json:"title"`
-	Description          string    `json:"description"`
-	RequiredCapabilities []string  `json:"required_capabilities"`
-	Priority             Priority  `json:"priority"`
-	Status               Status    `json:"status"`
-	AssignedAgentID      string    `json:"assigned_agent_id,omitempty"`
-	Result               string    `json:"result,omitempty"`
-	ErrorMsg             string    `json:"error,omitempty"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
-	CompletedAt          *time.Time `json:"completed_at,omitempty"`
+	ID                   string          `json:"id"`
+	Title                string          `json:"title"`
+	Description          string          `json:"description"`
+	RequiredCapabilities []string        `json:"required_capabilities"`
+	Priority             Priority        `json:"priority"`
+	Status               Status          `json:"status"`
+	AssignedAgentID      string          `json:"assigned_agent_id,omitempty"`
+	Result               string          `json:"result,omitempty"`
+	ErrorMsg             string          `json:"error,omitempty"`
+	ReportChannel        *ReportChannel  `json:"report_channel,omitempty"`
+	CreatedAt            time.Time       `json:"created_at"`
+	UpdatedAt            time.Time       `json:"updated_at"`
+	CompletedAt          *time.Time      `json:"completed_at,omitempty"`
 }
 
 type Store struct {


### PR DESCRIPTION
## 变更说明

实现 Issue #10：通信链路 + channel 汇报机制。

### 设计原则
Hub 不直接耦合 Discord/Feishu SDK，用 outgoing webhook 回调方式，接收方自行处理路由。

### 改动

**`internal/task/task.go`**
- 新增 `ReportChannel` struct：`webhook_url`、`discord_thread_id`、`feishu_chat_id`
- `Task` 新增 `report_channel *ReportChannel` 字段

**`internal/store/store.go`**
- Migration：`tasks` 表新增 `report_channel JSONB` 列（idempotent `ADD COLUMN IF NOT EXISTS`）

**`internal/task/pg.go`**
- `Create` 接受 `*ReportChannel` 参数，序列化为 JSONB 写入
- `Get` / `List` / `scanTask` 读取并反序列化 `report_channel`

**`internal/notify/webhook.go`** _(新文件)_
- `TaskEvent` payload struct
- `Send(ctx, webhookURL, evt)` — 10s 超时 HTTP POST，非阻塞

**`cmd/server/main.go`**
- `createTask` 支持 `report_channel` 入参
- `completeTask` / `failTask` 完成后 goroutine 异步触发 webhook

### 使用示例

```bash
curl -X POST http://localhost:8080/api/v1/tasks \
  -H "Content-Type: application/json" \
  -d '{
    "title": "分析今日美股",
    "required_capabilities": ["stock_analysis"],
    "report_channel": {
      "webhook_url": "https://your-receiver/webhook",
      "discord_thread_id": "1234567890"
    }
  }'
```

任务完成时 hub 会 POST：
```json
{
  "event": "task.done",
  "task_id": "...",
  "status": "done",
  "result": "...",
  "discord_thread_id": "1234567890",
  "completed_at": "2026-03-07T..."
}
```

### 测试
`go build ./...` 通过 ✅