### PR TITLE
feat: tasks?status=active filter + GET /api/v1/tasks/recent?limit=n

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -98,6 +99,7 @@ func main() {
 	// Task routes
 	r.Post("/api/v1/tasks", s.createTask)
 	r.Get("/api/v1/tasks", s.listTasks)
+	r.Get("/api/v1/tasks/recent", s.listRecentTasks)
 	r.Get("/api/v1/tasks/{id}", s.getTask)
 	r.Patch("/api/v1/tasks/{id}/claim", s.claimTask)
 	r.Patch("/api/v1/tasks/{id}/complete", s.completeTask)
@@ -200,6 +202,19 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	tasks, err := s.tasks.List(r.Context(), status)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResp(w, http.StatusOK, tasks)
+}
+
+func (s *Server) listRecentTasks(w http.ResponseWriter, r *http.Request) {
+	limit := 10
+	if n := r.URL.Query().Get("limit"); n != "" {
+		fmt.Sscanf(n, "%d", &limit)
+	}
+	tasks, err := s.tasks.ListRecent(r.Context(), limit)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/task/pg.go
+++ b/internal/task/pg.go
@@ -64,17 +64,55 @@ func (s *PGStore) Get(ctx context.Context, id string) (*Task, error) {
 func (s *PGStore) List(ctx context.Context, statusFilter string) ([]*Task, error) {
 	var rows interface{ Scan(...any) error }
 	var err error
-	if statusFilter == "" {
+	switch statusFilter {
+	case "":
 		rows, err = s.db.PG.Query(ctx,
 			`SELECT id,title,description,required_capabilities,priority,status,
 			        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
 			 FROM tasks ORDER BY priority DESC, created_at ASC`)
-	} else {
+	case "active": // not done and not failed
+		rows, err = s.db.PG.Query(ctx,
+			`SELECT id,title,description,required_capabilities,priority,status,
+			        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
+			 FROM tasks WHERE status NOT IN ('done','failed') ORDER BY priority DESC, created_at ASC`)
+	default:
 		rows, err = s.db.PG.Query(ctx,
 			`SELECT id,title,description,required_capabilities,priority,status,
 			        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
 			 FROM tasks WHERE status=$1 ORDER BY priority DESC, created_at ASC`, statusFilter)
 	}
+	if err != nil {
+		return nil, err
+	}
+	type closer interface{ Close() }
+	if c, ok := rows.(closer); ok {
+		defer c.Close()
+	}
+	type rower interface {
+		Next() bool
+		Scan(...any) error
+		Err() error
+	}
+	r := rows.(rower)
+	var tasks []*Task
+	for r.Next() {
+		t, err := scanTask(r)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, r.Err()
+}
+
+func (s *PGStore) ListRecent(ctx context.Context, limit int) ([]*Task, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 10
+	}
+	rows, err := s.db.PG.Query(ctx,
+		`SELECT id,title,description,required_capabilities,priority,status,
+		        assigned_agent_id,result,error,report_channel,created_at,updated_at,completed_at
+		 FROM tasks ORDER BY updated_at DESC LIMIT $1`, limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
两个小 API 增强：

1. `GET /api/v1/tasks?status=active` — 返回所有未完成任务（pending + running），排除 done/failed
2. `GET /api/v1/tasks/recent?limit=n` — 按 `updated_at DESC` 返回最新 N 条（默认10，上限100）

用途：状态报告、监控面板、agent 巡查任务时只看活跃任务。