### PR TITLE
feat: SaaS multi-tenant User/Project + task project_id + assigned_to filter (closes #24)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/claw-works/claw-hub/internal/agent"
 	"github.com/claw-works/claw-hub/internal/hub"
 	"github.com/claw-works/claw-hub/internal/notify"
+	"github.com/claw-works/claw-hub/internal/project"
 	"github.com/claw-works/claw-hub/internal/store"
 	"github.com/claw-works/claw-hub/internal/task"
 	"github.com/claw-works/claw-hub/pkg/protocol"
@@ -26,9 +27,10 @@ var upgrader = websocket.Upgrader{
 }
 
 type Server struct {
-	agents *agent.PGRegistry
-	tasks  *task.PGStore
-	hub    *hub.Hub
+	agents   *agent.PGRegistry
+	tasks    *task.PGStore
+	projects *project.PGStore
+	hub      *hub.Hub
 }
 
 func getenv(key, fallback string) string {
@@ -56,9 +58,10 @@ func main() {
 	h.SetInbox(hub.NewMongoInbox(db.Mongo))
 
 	s := &Server{
-		agents: agent.NewPGRegistry(db),
-		tasks:  task.NewPGStore(db),
-		hub:    h,
+		agents:   agent.NewPGRegistry(db),
+		tasks:    task.NewPGStore(db),
+		projects: project.NewPGStore(db),
+		hub:      h,
 	}
 
 	// Wire up WS REGISTER → update agent capabilities + last_seen in DB
@@ -172,6 +175,16 @@ func main() {
 		jsonResp(w, http.StatusOK, map[string]string{"status": "ok", "service": "claw-hub"})
 	})
 
+	// User routes
+	r.Post("/api/v1/users", s.createUser)
+	r.Get("/api/v1/users", s.listUsers)
+
+	// Project routes
+	r.Post("/api/v1/projects", s.createProject)
+	r.Get("/api/v1/projects", s.listProjects)
+	r.Get("/api/v1/projects/{id}", s.getProject)
+	r.Get("/api/v1/projects/{id}/tasks", s.listProjectTasks)
+
 	// Agent routes
 	r.Post("/api/v1/agents/register", s.registerAgent)
 	r.Post("/api/v1/agents/{id}/heartbeat", s.agentHeartbeat)
@@ -254,12 +267,13 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 		RequiredCapabilities []string            `json:"required_capabilities"`
 		Priority             int                 `json:"priority"`
 		ReportChannel        *task.ReportChannel `json:"report_channel"`
+		ProjectID            string              `json:"project_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	t, err := s.tasks.Create(r.Context(), req.Title, req.Description, req.RequiredCapabilities, task.Priority(req.Priority), req.ReportChannel)
+	t, err := s.tasks.Create(r.Context(), req.Title, req.Description, req.RequiredCapabilities, task.Priority(req.Priority), req.ReportChannel, req.ProjectID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -271,7 +285,6 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 		if err == nil && agentID != "" {
 			if s.tasks.Claim(r.Context(), t.ID, agentID) {
 				t, _ = s.tasks.Get(r.Context(), t.ID)
-				// Send TaskAssignPayload via protocol.Envelope
 				var rc *protocol.ReportChannel
 				if t.ReportChannel != nil {
 					rc = &protocol.ReportChannel{
@@ -291,13 +304,11 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 						Description:   t.Description,
 						Requirements:  t.RequiredCapabilities,
 						Priority:      int(t.Priority),
-						Deadline:      (*time.Time)(nil), // set via assigned_at + 5min
 						ReportChannel: rc,
 					},
 				})
 				log.Printf("createTask: assigned %s → agent %s", t.ID, agentID)
 			} else {
-				// Claim failed (race), release agent back to online
 				s.agents.SetOnline(r.Context(), agentID)
 			}
 		}
@@ -307,8 +318,12 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
-	status := r.URL.Query().Get("status")
-	tasks, err := s.tasks.List(r.Context(), status)
+	f := task.ListFilter{
+		Status:     r.URL.Query().Get("status"),
+		AssignedTo: r.URL.Query().Get("assigned_to"),
+		ProjectID:  r.URL.Query().Get("project_id"),
+	}
+	tasks, err := s.tasks.ListFiltered(r.Context(), f)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -539,6 +554,93 @@ func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 			s.hub.Broadcast(msg)
 		}
 	})
+}
+
+// ─── User Handlers ─────────────────────────────────────────────────────────
+
+func (s *Server) createUser(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+	u, err := s.projects.CreateUser(r.Context(), req.Name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResp(w, http.StatusCreated, u)
+}
+
+func (s *Server) listUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := s.projects.ListUsers(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if users == nil {
+		users = []*project.User{}
+	}
+	jsonResp(w, http.StatusOK, users)
+}
+
+// ─── Project Handlers ───────────────────────────────────────────────────────
+
+func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		UserID string `json:"user_id"`
+		Name   string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" {
+		http.Error(w, "user_id and name required", http.StatusBadRequest)
+		return
+	}
+	p, err := s.projects.CreateProject(r.Context(), req.UserID, req.Name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResp(w, http.StatusCreated, p)
+}
+
+func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	projects, err := s.projects.ListProjects(r.Context(), userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if projects == nil {
+		projects = []*project.Project{}
+	}
+	jsonResp(w, http.StatusOK, projects)
+}
+
+func (s *Server) getProject(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	p, err := s.projects.GetProject(r.Context(), id)
+	if err != nil {
+		http.Error(w, "project not found", http.StatusNotFound)
+		return
+	}
+	jsonResp(w, http.StatusOK, p)
+}
+
+func (s *Server) listProjectTasks(w http.ResponseWriter, r *http.Request) {
+	projectID := chi.URLParam(r, "id")
+	f := task.ListFilter{
+		Status:     r.URL.Query().Get("status"),
+		AssignedTo: r.URL.Query().Get("assigned_to"),
+		ProjectID:  projectID,
+	}
+	tasks, err := s.tasks.ListFiltered(r.Context(), f)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResp(w, http.StatusOK, tasks)
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────────────

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,143 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/claw-works/claw-hub/internal/store"
+	"github.com/google/uuid"
+)
+
+// User represents a tenant in the SaaS multi-tenant model.
+type User struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	APIKey    string    `json:"api_key,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Project belongs to a User and groups Tasks and Agents.
+type Project struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// PGStore handles User and Project persistence in PostgreSQL.
+type PGStore struct {
+	db *store.DB
+}
+
+func NewPGStore(db *store.DB) *PGStore {
+	return &PGStore{db: db}
+}
+
+// ── User ──────────────────────────────────────────────────────────────────────
+
+func (s *PGStore) CreateUser(ctx context.Context, name string) (*User, error) {
+	u := &User{
+		ID:        uuid.New().String(),
+		Name:      name,
+		APIKey:    uuid.New().String(), // simple random API key for now
+		CreatedAt: time.Now(),
+	}
+	_, err := s.db.PG.Exec(ctx,
+		`INSERT INTO users (id, name, api_key, created_at) VALUES ($1,$2,$3,$4)`,
+		u.ID, u.Name, u.APIKey, u.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+	return u, nil
+}
+
+func (s *PGStore) GetUser(ctx context.Context, id string) (*User, error) {
+	u := &User{}
+	err := s.db.PG.QueryRow(ctx,
+		`SELECT id, name, api_key, created_at FROM users WHERE id=$1`, id,
+	).Scan(&u.ID, &u.Name, &u.APIKey, &u.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	return u, nil
+}
+
+func (s *PGStore) ListUsers(ctx context.Context) ([]*User, error) {
+	rows, err := s.db.PG.Query(ctx,
+		`SELECT id, name, api_key, created_at FROM users ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var users []*User
+	for rows.Next() {
+		u := &User{}
+		if err := rows.Scan(&u.ID, &u.Name, &u.APIKey, &u.CreatedAt); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}
+
+// ── Project ───────────────────────────────────────────────────────────────────
+
+func (s *PGStore) CreateProject(ctx context.Context, userID, name string) (*Project, error) {
+	p := &Project{
+		ID:        uuid.New().String(),
+		UserID:    userID,
+		Name:      name,
+		CreatedAt: time.Now(),
+	}
+	_, err := s.db.PG.Exec(ctx,
+		`INSERT INTO projects (id, user_id, name, created_at) VALUES ($1,$2,$3,$4)`,
+		p.ID, p.UserID, p.Name, p.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create project: %w", err)
+	}
+	return p, nil
+}
+
+func (s *PGStore) GetProject(ctx context.Context, id string) (*Project, error) {
+	p := &Project{}
+	err := s.db.PG.QueryRow(ctx,
+		`SELECT id, user_id, name, created_at FROM projects WHERE id=$1`, id,
+	).Scan(&p.ID, &p.UserID, &p.Name, &p.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("get project: %w", err)
+	}
+	return p, nil
+}
+
+func (s *PGStore) ListProjects(ctx context.Context, userID string) ([]*Project, error) {
+	var rows interface {
+		Next() bool
+		Scan(...any) error
+		Err() error
+		Close()
+	}
+	var err error
+	if userID != "" {
+		rows, err = s.db.PG.Query(ctx,
+			`SELECT id, user_id, name, created_at FROM projects WHERE user_id=$1 ORDER BY created_at DESC`, userID)
+	} else {
+		rows, err = s.db.PG.Query(ctx,
+			`SELECT id, user_id, name, created_at FROM projects ORDER BY created_at DESC`)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var projects []*Project
+	for rows.Next() {
+		p := &Project{}
+		if err := rows.Scan(&p.ID, &p.UserID, &p.Name, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, rows.Err()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -43,6 +43,22 @@ func Connect(ctx context.Context, pgDSN, mongoURI, mongoDBName string) (*DB, err
 // Migrate runs idempotent DDL for PostgreSQL.
 func (db *DB) Migrate(ctx context.Context) error {
 	_, err := db.PG.Exec(ctx, `
+		-- ── Multi-tenant: users & projects ───────────────────────────────────────
+		CREATE TABLE IF NOT EXISTS users (
+			id         TEXT PRIMARY KEY,
+			name       TEXT NOT NULL,
+			api_key    TEXT NOT NULL UNIQUE,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE TABLE IF NOT EXISTS projects (
+			id         TEXT PRIMARY KEY,
+			user_id    TEXT NOT NULL REFERENCES users(id),
+			name       TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		-- ── Agents ───────────────────────────────────────────────────────────────
 		CREATE TABLE IF NOT EXISTS agents (
 			id              TEXT PRIMARY KEY,
 			name            TEXT NOT NULL,
@@ -52,6 +68,7 @@ func (db *DB) Migrate(ctx context.Context) error {
 			last_heartbeat  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
 
+		-- ── Tasks ────────────────────────────────────────────────────────────────
 		CREATE TABLE IF NOT EXISTS tasks (
 			id                    TEXT PRIMARY KEY,
 			title                 TEXT NOT NULL,
@@ -68,10 +85,17 @@ func (db *DB) Migrate(ctx context.Context) error {
 			completed_at          TIMESTAMPTZ
 		);
 
-		-- Idempotent: add report_channel if the table already existed without it.
-		ALTER TABLE tasks ADD COLUMN IF NOT EXISTS report_channel JSONB;
-		-- Idempotent: add assigned_at for ACK timeout tracking.
-		ALTER TABLE tasks ADD COLUMN IF NOT EXISTS assigned_at TIMESTAMPTZ;
+		-- Idempotent column additions
+		ALTER TABLE tasks   ADD COLUMN IF NOT EXISTS report_channel JSONB;
+		ALTER TABLE tasks   ADD COLUMN IF NOT EXISTS assigned_at    TIMESTAMPTZ;
+		ALTER TABLE tasks   ADD COLUMN IF NOT EXISTS project_id     TEXT REFERENCES projects(id);
+		ALTER TABLE agents  ADD COLUMN IF NOT EXISTS user_id        TEXT REFERENCES users(id);
+
+		-- Indexes for common queries
+		CREATE INDEX IF NOT EXISTS idx_tasks_project_id   ON tasks(project_id);
+		CREATE INDEX IF NOT EXISTS idx_tasks_assigned_to  ON tasks(assigned_agent_id);
+		CREATE INDEX IF NOT EXISTS idx_agents_user_id     ON agents(user_id);
+		CREATE INDEX IF NOT EXISTS idx_projects_user_id   ON projects(user_id);
 	`)
 	if err != nil {
 		return fmt.Errorf("migrate: %w", err)

--- a/internal/task/pg.go
+++ b/internal/task/pg.go
@@ -19,7 +19,7 @@ func NewPGStore(db *store.DB) *PGStore {
 	return &PGStore{db: db}
 }
 
-func (s *PGStore) Create(ctx context.Context, title, description string, required []string, priority Priority, rc *ReportChannel) (*Task, error) {
+func (s *PGStore) Create(ctx context.Context, title, description string, required []string, priority Priority, rc *ReportChannel, projectID string) (*Task, error) {
 	t := &Task{
 		ID:                   uuid.New().String(),
 		Title:                title,
@@ -28,6 +28,7 @@ func (s *PGStore) Create(ctx context.Context, title, description string, require
 		Priority:             priority,
 		Status:               StatusPending,
 		ReportChannel:        rc,
+		ProjectID:            projectID,
 		CreatedAt:            time.Now(),
 		UpdatedAt:            time.Now(),
 	}
@@ -41,10 +42,15 @@ func (s *PGStore) Create(ctx context.Context, title, description string, require
 		}
 	}
 
+	var pid *string
+	if projectID != "" {
+		pid = &projectID
+	}
+
 	_, err := s.db.PG.Exec(ctx,
-		`INSERT INTO tasks (id, title, description, required_capabilities, priority, status, report_channel, created_at, updated_at)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-		t.ID, t.Title, t.Description, t.RequiredCapabilities, t.Priority, string(t.Status), rcJSON, t.CreatedAt, t.UpdatedAt,
+		`INSERT INTO tasks (id, title, description, required_capabilities, priority, status, report_channel, project_id, created_at, updated_at)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+		t.ID, t.Title, t.Description, t.RequiredCapabilities, t.Priority, string(t.Status), rcJSON, pid, t.CreatedAt, t.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create task: %w", err)
@@ -56,31 +62,55 @@ func (s *PGStore) Create(ctx context.Context, title, description string, require
 func (s *PGStore) Get(ctx context.Context, id string) (*Task, error) {
 	row := s.db.PG.QueryRow(ctx,
 		`SELECT id,title,description,required_capabilities,priority,status,
-		        assigned_agent_id,result,error,report_channel,assigned_at,created_at,updated_at,completed_at
+		        assigned_agent_id,result,error,report_channel,assigned_at,project_id,created_at,updated_at,completed_at
 		 FROM tasks WHERE id=$1`, id)
 	return scanTask(row)
 }
 
+// ListFilter holds optional filters for List queries.
+type ListFilter struct {
+	Status     string // "" = all, "active" = not done/failed, or exact status
+	ProjectID  string // filter by project
+	AssignedTo string // filter by agent id
+}
+
 func (s *PGStore) List(ctx context.Context, statusFilter string) ([]*Task, error) {
-	var rows interface{ Scan(...any) error }
-	var err error
-	switch statusFilter {
+	return s.ListFiltered(ctx, ListFilter{Status: statusFilter})
+}
+
+func (s *PGStore) ListFiltered(ctx context.Context, f ListFilter) ([]*Task, error) {
+	base := `SELECT id,title,description,required_capabilities,priority,status,
+		        assigned_agent_id,result,error,report_channel,assigned_at,project_id,created_at,updated_at,completed_at
+		 FROM tasks WHERE 1=1`
+	args := []interface{}{}
+	n := 1
+
+	switch f.Status {
+	case "active":
+		base += " AND status NOT IN ('done','failed')"
 	case "":
-		rows, err = s.db.PG.Query(ctx,
-			`SELECT id,title,description,required_capabilities,priority,status,
-			        assigned_agent_id,result,error,report_channel,assigned_at,created_at,updated_at,completed_at
-			 FROM tasks ORDER BY priority DESC, created_at ASC`)
-	case "active": // not done and not failed
-		rows, err = s.db.PG.Query(ctx,
-			`SELECT id,title,description,required_capabilities,priority,status,
-			        assigned_agent_id,result,error,report_channel,assigned_at,created_at,updated_at,completed_at
-			 FROM tasks WHERE status NOT IN ('done','failed') ORDER BY priority DESC, created_at ASC`)
+		// no filter
 	default:
-		rows, err = s.db.PG.Query(ctx,
-			`SELECT id,title,description,required_capabilities,priority,status,
-			        assigned_agent_id,result,error,report_channel,assigned_at,created_at,updated_at,completed_at
-			 FROM tasks WHERE status=$1 ORDER BY priority DESC, created_at ASC`, statusFilter)
+		base += fmt.Sprintf(" AND status=$%d", n)
+		args = append(args, f.Status)
+		n++
 	}
+
+	if f.ProjectID != "" {
+		base += fmt.Sprintf(" AND project_id=$%d", n)
+		args = append(args, f.ProjectID)
+		n++
+	}
+
+	if f.AssignedTo != "" {
+		base += fmt.Sprintf(" AND assigned_agent_id=$%d", n)
+		args = append(args, f.AssignedTo)
+		n++
+	}
+
+	base += " ORDER BY priority DESC, created_at ASC"
+
+	rows, err := s.db.PG.Query(ctx, base, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +141,7 @@ func (s *PGStore) ListRecent(ctx context.Context, limit int) ([]*Task, error) {
 	}
 	rows, err := s.db.PG.Query(ctx,
 		`SELECT id,title,description,required_capabilities,priority,status,
-		        assigned_agent_id,result,error,report_channel,assigned_at,created_at,updated_at,completed_at
+		        assigned_agent_id,result,error,report_channel,assigned_at,project_id,created_at,updated_at,completed_at
 		 FROM tasks ORDER BY updated_at DESC LIMIT $1`, limit)
 	if err != nil {
 		return nil, err
@@ -222,12 +252,12 @@ type scanner interface {
 func scanTask(s scanner) (*Task, error) {
 	t := &Task{}
 	var status string
-	var assignedAgentID, result, errMsg *string
+	var assignedAgentID, result, errMsg, projectID *string
 	var rcJSON []byte
 	err := s.Scan(
 		&t.ID, &t.Title, &t.Description, &t.RequiredCapabilities,
 		&t.Priority, &status, &assignedAgentID, &result, &errMsg, &rcJSON,
-		&t.AssignedAt, &t.CreatedAt, &t.UpdatedAt, &t.CompletedAt,
+		&t.AssignedAt, &projectID, &t.CreatedAt, &t.UpdatedAt, &t.CompletedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -241,6 +271,9 @@ func scanTask(s scanner) (*Task, error) {
 	}
 	if errMsg != nil {
 		t.ErrorMsg = *errMsg
+	}
+	if projectID != nil {
+		t.ProjectID = *projectID
 	}
 	if len(rcJSON) > 0 {
 		var rc ReportChannel

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -41,6 +41,7 @@ type Task struct {
 	Priority             Priority        `json:"priority"`
 	Status               Status          `json:"status"`
 	AssignedAgentID      string          `json:"assigned_agent_id,omitempty"`
+	ProjectID            string          `json:"project_id,omitempty"`
 	Result               string          `json:"result,omitempty"`
 	ErrorMsg             string          `json:"error,omitempty"`
 	ReportChannel        *ReportChannel  `json:"report_channel,omitempty"`


### PR DESCRIPTION
实现 Issue #24 多租户架构。

- `users` + `projects` 表 + PGStore
- `tasks.project_id` / `agents.user_id` 新列
- `ListFilter{Status,ProjectID,AssignedTo}` 动态查询
- 新路由：`/api/v1/users` / `/api/v1/projects` / `/api/v1/projects/{id}/tasks`
- `listTasks` 支持 `?assigned_to=` 和 `?project_id=`

`go build ./...` 通过 ✅