### PR TITLE
feat: API Key authentication via X-API-Key header (closes #7)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/claw-works/claw-hub/internal/agent"
+	"github.com/claw-works/claw-hub/internal/auth"
 	"github.com/claw-works/claw-hub/internal/hub"
 	"github.com/claw-works/claw-hub/internal/notify"
 	"github.com/claw-works/claw-hub/internal/project"
@@ -170,43 +171,50 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(corsMiddleware)
 
-	// Health
+	// Public routes (no auth required)
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		jsonResp(w, http.StatusOK, map[string]string{"status": "ok", "service": "claw-hub"})
 	})
+	r.Get("/ws", s.wsHandler)
 
-	// User routes
-	r.Post("/api/v1/users", s.createUser)
-	r.Get("/api/v1/users", s.listUsers)
-
-	// Project routes
-	r.Post("/api/v1/projects", s.createProject)
-	r.Get("/api/v1/projects", s.listProjects)
-	r.Get("/api/v1/projects/{id}", s.getProject)
-	r.Get("/api/v1/projects/{id}/tasks", s.listProjectTasks)
-
-	// Agent routes
+	// Agent routes — no API key needed (agents identify by agent_id)
 	r.Post("/api/v1/agents/register", s.registerAgent)
 	r.Post("/api/v1/agents/{id}/heartbeat", s.agentHeartbeat)
-	r.Get("/api/v1/agents", s.listAgents)
 	r.Get("/api/v1/agents/{id}/inbox", s.getInbox)
 
-	// Task routes
-	r.Post("/api/v1/tasks", s.createTask)
-	r.Get("/api/v1/tasks", s.listTasks)
-	r.Get("/api/v1/tasks/recent", s.listRecentTasks)
-	r.Get("/api/v1/tasks/{id}", s.getTask)
-	r.Get("/api/v1/tasks/{id}/events", s.getTaskEvents)
-	r.Patch("/api/v1/tasks/{id}/claim", s.claimTask)
-	r.Patch("/api/v1/tasks/{id}/complete", s.completeTask)
-	r.Patch("/api/v1/tasks/{id}/fail", s.failTask)
-	r.Post("/api/v1/tasks/reassign", s.reassignPending)
+	// User creation is public (bootstrap: create first user to get API key)
+	r.Post("/api/v1/users", s.createUser)
 
-	// Message routes
-	r.Post("/api/v1/messages/send", s.sendMessage)
+	// Protected routes — require X-API-Key
+	r.Group(func(r chi.Router) {
+		r.Use(auth.Middleware(s.projects))
 
-	// WebSocket
-	r.Get("/ws", s.wsHandler)
+		// User routes
+		r.Get("/api/v1/users", s.listUsers)
+
+		// Agent routes (management)
+		r.Get("/api/v1/agents", s.listAgents)
+
+		// Project routes
+		r.Post("/api/v1/projects", s.createProject)
+		r.Get("/api/v1/projects", s.listProjects)
+		r.Get("/api/v1/projects/{id}", s.getProject)
+		r.Get("/api/v1/projects/{id}/tasks", s.listProjectTasks)
+
+		// Task routes
+		r.Post("/api/v1/tasks", s.createTask)
+		r.Get("/api/v1/tasks", s.listTasks)
+		r.Get("/api/v1/tasks/recent", s.listRecentTasks)
+		r.Get("/api/v1/tasks/{id}", s.getTask)
+		r.Get("/api/v1/tasks/{id}/events", s.getTaskEvents)
+		r.Patch("/api/v1/tasks/{id}/claim", s.claimTask)
+		r.Patch("/api/v1/tasks/{id}/complete", s.completeTask)
+		r.Patch("/api/v1/tasks/{id}/fail", s.failTask)
+		r.Post("/api/v1/tasks/reassign", s.reassignPending)
+
+		// Message routes
+		r.Post("/api/v1/messages/send", s.sendMessage)
+	})
 
 	addr := getenv("ADDR", ":8080")
 	log.Printf("claw-hub listening on %s", addr)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/claw-works/claw-hub/internal/project"
+)
+
+type contextKey string
+
+const UserContextKey contextKey = "auth_user"
+
+// Middleware validates X-API-Key header.
+// If the key is valid, injects the User into the request context.
+// If the key is missing or invalid, returns 401.
+func Middleware(store *project.PGStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiKey := r.Header.Get("X-API-Key")
+			if apiKey == "" {
+				http.Error(w, `{"error":"X-API-Key required"}`, http.StatusUnauthorized)
+				return
+			}
+			user, err := store.GetUserByAPIKey(r.Context(), apiKey)
+			if err != nil {
+				http.Error(w, `{"error":"invalid API key"}`, http.StatusUnauthorized)
+				return
+			}
+			ctx := context.WithValue(r.Context(), UserContextKey, user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// FromContext extracts the authenticated user from context.
+// Returns nil if not authenticated.
+func FromContext(ctx context.Context) *project.User {
+	u, _ := ctx.Value(UserContextKey).(*project.User)
+	return u
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -64,6 +64,17 @@ func (s *PGStore) GetUser(ctx context.Context, id string) (*User, error) {
 	return u, nil
 }
 
+func (s *PGStore) GetUserByAPIKey(ctx context.Context, apiKey string) (*User, error) {
+	u := &User{}
+	err := s.db.PG.QueryRow(ctx,
+		`SELECT id, name, api_key, created_at FROM users WHERE api_key=$1`, apiKey,
+	).Scan(&u.ID, &u.Name, &u.APIKey, &u.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("get user by api key: %w", err)
+	}
+	return u, nil
+}
+
 func (s *PGStore) ListUsers(ctx context.Context) ([]*User, error) {
 	rows, err := s.db.PG.Query(ctx,
 		`SELECT id, name, api_key, created_at FROM users ORDER BY created_at DESC`)


### PR DESCRIPTION
## 变更

- `internal/auth/middleware.go` — 验证 `X-API-Key` header，注入 User 到 context
- `project.GetUserByAPIKey` — 通过 api_key 字段查用户
- 路由分组：受保护路由统一加 auth 中间件

## 受保护（需要 X-API-Key）
所有 `/api/v1/*` 管理端点：users(list)、projects、tasks、messages

## 公开（不需要认证）
- `GET /health`
- `GET /ws`（WS 用 agent_id 识别）
- `POST /api/v1/agents/register`
- `POST /api/v1/agents/{id}/heartbeat`
- `GET /api/v1/agents/{id}/inbox`
- `POST /api/v1/users`（bootstrap：创建第一个用户拿 API key）

## 测试
```bash
# 无 key → 401
curl http://10.0.1.24:8080/api/v1/tasks
# → {"error":"X-API-Key required"}

# 有 key → 正常
curl -H "X-API-Key: <key>" http://10.0.1.24:8080/api/v1/tasks
```

closes #7