### PR TITLE
feat: add message quote/reply support (#35)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1327,6 +1327,7 @@ func (s *Server) postRoomMessage(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		SenderAgentID string                 `json:"sender_agent_id"`
 		Content       string                 `json:"content"`
+		QuoteID       string                 `json:"quote_id,omitempty"`
 		Metadata      map[string]interface{} `json:"metadata,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Content == "" {
@@ -1338,7 +1339,7 @@ func (s *Server) postRoomMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	msg, err := s.rooms.Post(r.Context(), roomID, req.SenderAgentID, req.Content, req.Metadata)
+	msg, err := s.rooms.Post(r.Context(), roomID, req.SenderAgentID, req.Content, req.QuoteID, req.Metadata)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1583,7 +1584,7 @@ func (s *Server) generateDailyReports(ctx context.Context) {
 
 		// Post to room (use user_id from project)
 		roomID := "user:" + p.UserID + ":default"
-		if _, err := s.rooms.Post(ctx, roomID, "hub", summary, nil); err != nil {
+		if _, err := s.rooms.Post(ctx, roomID, "hub", summary, "", nil); err != nil {
 			log.Printf("daily-report: post room error for %s: %v", p.ID, err)
 		} else {
 			s.monitor.Broadcast("room.message", map[string]interface{}{"room_id": roomID, "content": summary})

--- a/internal/room/room.go
+++ b/internal/room/room.go
@@ -22,12 +22,21 @@ const (
 	defaultLimit = 20
 )
 
+// QuotedMessage is an embedded snapshot of a quoted message.
+type QuotedMessage struct {
+	ID            string `bson:"id"             json:"id"`
+	SenderAgentID string `bson:"sender_agent_id" json:"sender_agent_id"`
+	Content       string `bson:"content"        json:"content"`
+}
+
 // Message is a single chat room message.
 type Message struct {
 	ID            string                 `bson:"_id"      json:"id"`
 	RoomID        string                 `bson:"room_id"  json:"room_id"`
 	SenderAgentID string                 `bson:"sender_agent_id" json:"sender_agent_id"`
 	Content       string                 `bson:"content"  json:"content"`
+	QuoteID       string                 `bson:"quote_id,omitempty"  json:"quote_id,omitempty"`
+	Quote         *QuotedMessage         `bson:"quote,omitempty"     json:"quote,omitempty"`
 	Metadata      map[string]interface{} `bson:"metadata,omitempty" json:"metadata,omitempty"`
 	CreatedAt     time.Time              `bson:"created_at" json:"created_at"`
 	ExpiresAt     time.Time              `bson:"expires_at" json:"-"`
@@ -68,7 +77,8 @@ func DefaultRoomID(userID string) string {
 }
 
 // Post stores a new message in the room.
-func (s *Store) Post(ctx context.Context, roomID, senderAgentID, content string, metadata map[string]interface{}) (*Message, error) {
+// If quoteID is non-empty, the quoted message is looked up and embedded as a snapshot.
+func (s *Store) Post(ctx context.Context, roomID, senderAgentID, content, quoteID string, metadata map[string]interface{}) (*Message, error) {
 	now := time.Now().UTC()
 	msg := &Message{
 		ID:            uuid.New().String(),
@@ -79,12 +89,43 @@ func (s *Store) Post(ctx context.Context, roomID, senderAgentID, content string,
 		CreatedAt:     now,
 		ExpiresAt:     now.Add(messageTTL),
 	}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if _, err := s.coll.InsertOne(ctx, msg); err != nil {
+	if quoteID != "" {
+		fetchCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		var quoted Message
+		if err := s.coll.FindOne(fetchCtx, bson.M{"_id": quoteID}).Decode(&quoted); err == nil {
+			msg.QuoteID = quoteID
+			// Truncate snapshot content to 200 chars to keep documents small.
+			snap := quoted.Content
+			if len(snap) > 200 {
+				snap = snap[:200] + "…"
+			}
+			msg.Quote = &QuotedMessage{
+				ID:            quoted.ID,
+				SenderAgentID: quoted.SenderAgentID,
+				Content:       snap,
+			}
+		} else {
+			return nil, fmt.Errorf("room post: quote_id %q not found", quoteID)
+		}
+	}
+	postCtx, cancel2 := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel2()
+	if _, err := s.coll.InsertOne(postCtx, msg); err != nil {
 		return nil, fmt.Errorf("room post: %w", err)
 	}
 	return msg, nil
+}
+
+// GetByID fetches a single message by its ID.
+func (s *Store) GetByID(ctx context.Context, id string) (*Message, error) {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	var msg Message
+	if err := s.coll.FindOne(ctx, bson.M{"_id": id}).Decode(&msg); err != nil {
+		return nil, fmt.Errorf("room getbyid: %w", err)
+	}
+	return &msg, nil
 }
 
 // List returns up to limit messages in the room, sorted newest-first.


### PR DESCRIPTION
## 消息引用功能 Phase 1 - 后端

### 变更

- `room.Message` 新增 `quote_id`（存储引用消息ID）和 `quote`（嵌入快照）字段
- `Post()` 接受可选 `quoteID` 参数；若非空则验证被引用消息存在并嵌入快照（截断至200字）
- `postRoomMessage` handler 支持请求体中 `quote_id` 字段
- 新增 `GetByID()` 辅助方法
- 修复 daily-report 调用点

### API 使用

```json
POST /api/v1/rooms/{room_id}/messages
{
  "sender_agent_id": "...",
  "content": "回复内容",
  "quote_id": "被引用消息的ID"
}
```

### 返回示例

```json
{
  "id": "...",
  "content": "回复内容",
  "quote_id": "原消息ID",
  "quote": {
    "id": "原消息ID",
    "sender_agent_id": "...",
    "content": "原消息内容摘要（最多200字）"
  }
}
```

### 依赖

- 前端UI任务（pincer-monitor）独立进行，联调时按此接口对接